### PR TITLE
wip: save 'online' log to test 'offline' scenarios

### DIFF
--- a/coba/environments/supervised.py
+++ b/coba/environments/supervised.py
@@ -230,6 +230,7 @@ class SupervisedSimulation(SimulatedEnvironment):
                 action_indexes = dict(zip(actions,count()))
                 reward         = lambda label: MulticlassReward(n_actions, action_indexes[label])
 
+        # need all this info for the log
         if first_row_type == 0:
             for row in rows:
                 yield {'context':row.feats,'actions':actions,'rewards':reward(row.label)}

--- a/coba/experiments/process.py
+++ b/coba/experiments/process.py
@@ -131,6 +131,7 @@ class ProcessWorkItems(Filter[Iterable[WorkItem], Iterable[Any]]):
         chunk = list(chunk)
         empty_envs = set()
 
+        # this Finalize() triggers Repr() to run and remove the string names from the input
         finalizer = BatchSafe(Finalize())
 
         if not chunk: return

--- a/coba/pipes/rows.py
+++ b/coba/pipes/rows.py
@@ -513,7 +513,13 @@ class EncodeCatRows(Filter[Iterable[Union[Any,Dense,Sparse]], Iterable[Union[Any
             rows = rows
 
         if self._tipe =='onehot':
-            rows = Flatten().filter(rows)
+            if isinstance(first, Dense) and hasattr(first, "headers"): # do all dense rows have headers?
+                names_cols = [0] * len(first.headers)
+                for key, val in first.headers.items():
+                    names_cols[val] = key
+                rows = Flatten().filter(rows, names_cols[:-1])
+            else:
+                rows = Flatten().filter(rows)
 
         return rows
 

--- a/coba/primitives/__init__.py
+++ b/coba/primitives/__init__.py
@@ -1,6 +1,6 @@
 from coba.primitives.semantic import Context, Action, Actions, AIndex, Batch
 from coba.primitives.types import Categorical
-from coba.primitives.rows import Dense, Sparse, HashableDense, HashableSparse
+from coba.primitives.rows import NamedValue, Dense, Sparse, HashableDense, HashableSparse
 from coba.primitives.feedbacks import Feedback, SequenceFeedback, BatchFeedback
 from coba.primitives.rewards import Reward, L1Reward, HammingReward, BinaryReward, ScaleReward, SequenceReward, MulticlassReward, BatchReward
 
@@ -25,5 +25,6 @@ __all__ = [
     'AIndex',
     'Batch',
     'BatchReward',
-    'BatchFeedback'
+    'BatchFeedback',
+    'NamedValue'
 ]

--- a/coba/primitives/rows.py
+++ b/coba/primitives/rows.py
@@ -1,7 +1,11 @@
 from operator import eq
 from collections import abc
 from abc import ABC, abstractmethod
-from typing import Sequence, Iterator, Iterable, Any
+from typing import Sequence, Iterator, Iterable, Any, NamedTuple
+
+class NamedValue(NamedTuple):
+    name: str
+    value: Any
 
 class Dense(ABC):
     __slots__=()


### PR DESCRIPTION
Hey Mark, I wanted to keep the human readable name even after flattening the categorical type features. I make a big assumption rows.py, left it as a comment.

Could it be implemented as a Filter for the Environment? although I would still need to modify the Finalize call in process.py. Although it is a combination of Environment + first predict call to Learner, since we need access to label.

```
environments = cb.Environments.cache_dir('.coba_cache').from_openml(180,take=1500).shuffle(n=3).save_copy()
learners     = [cb.VowpalLearner(args="--cb_explore_adf --epsilon 0.05")]
experiment   = cb.Experiment(environments, learners)

experiment.run(quiet=False).plot_learners(err='se')
```

Sample log from openml(180):
`{"context": {"x": [["elevation", 3257.0], ["aspect", 83.0], ["slope", 20.0], ["horizontal_distance_to_hydrology", 0.0], ["Vertical_Distance_To_Hydrology", 0.0], ["Horizontal_Distance_To_Roadways", 1528.0], ["Hillshade_9am", 243.0], ["Hillshade_Noon", 201.0], ["Hillshade_3pm", 78.0], ["Horizontal_Distance_To_Fire_Points", 1794.0], ["wilderness_area1", 1.0], ["wilderness_area2", 0.0], ["wilderness_area3", 0.0], ["wilderness_area4", 0.0], ["soil_type_1_0", 1], ["soil_type_1_1", 0], ["soil_type_2_0", 1], ["soil_type_2_1", 0], ["soil_type_3_0", 1], ["soil_type_3_1", 0], ["soil_type_4_0", 1], ["soil_type_4_1", 0], ["soil_type_5_0", 1], ["soil_type_5_1", 0], ["soil_type_6_0", 1], ["soil_type_6_1", 0], ["soil_type_7_0", 1], ["soil_type_7_1", 0], ["soil_type_8_0", 1], ["soil_type_8_1", 0], ["soil_type_9_0", 1], ["soil_type_9_1", 0], ["soil_type_10_0", 1], ["soil_type_10_1", 0], ["soil_type_11_0", 1], ["soil_type_11_1", 0], ["soil_type_12_0", 1], ["soil_type_12_1", 0], ["soil_type_13_0", 1], ["soil_type_13_1", 0], ["soil_type_14_0", 1], ["soil_type_14_1", 0], ["soil_type_15_0", 1], ["soil_type_15_1", 0], ["soil_type_16_0", 1], ["soil_type_16_1", 0], ["soil_type_17_0", 1], ["soil_type_17_1", 0], ["soil_type_18_0", 1], ["soil_type_18_1", 0], ["soil_type_19_0", 1], ["soil_type_19_1", 0], ["soil_type_20_0", 1], ["soil_type_20_1", 0], ["soil_type_21_0", 1], ["soil_type_21_1", 0], ["soil_type_22_0", 1], ["soil_type_22_1", 0], ["soil_type_23_0", 1], ["soil_type_23_1", 0], ["soil_type_24_0", 1], ["soil_type_24_1", 0], ["soil_type_25_0", 1], ["soil_type_25_1", 0], ["soil_type_26_0", 1], ["soil_type_26_1", 0], ["soil_type_27_0", 1], ["soil_type_27_1", 0], ["soil_type_28_0", 1], ["soil_type_28_1", 0], ["soil_type_29_0", 1], ["soil_type_29_1", 0], ["soil_type_30_0", 1], ["soil_type_30_1", 0], ["soil_type_31_0", 1], ["soil_type_31_1", 0], ["soil_type_32_0", 1], ["soil_type_32_1", 0], ["soil_type_33_0", 1], ["soil_type_33_1", 0], ["soil_type_34_0", 1], ["soil_type_34_1", 0], ["soil_type_35_0", 1], ["soil_type_35_1", 0], ["soil_type_36_0", 1], ["soil_type_36_1", 0], ["soil_type_37_0", 1], ["soil_type_37_1", 0], ["soil_type_38_0", 0], ["soil_type_38_1", 1], ["soil_type_39_0", 1], ["soil_type_39_1", 0], ["soil_type_40_0", 1], ["soil_type_40_1", 0]]}, "adfs": [{"a": [1, 0, 0, 0, 0, 0, 0]}, {"a": [0, 1, 0, 0, 0, 0, 0]}, {"a": [0, 0, 1, 0, 0, 0, 0]}, {"a": [0, 0, 0, 1, 0, 0, 0]}, {"a": [0, 0, 0, 0, 1, 0, 0]}, {"a": [0, 0, 0, 0, 0, 1, 0]}, {"a": [0, 0, 0, 0, 0, 0, 1]}], "labels": ["1:-1:0.14286", null, null, null, null, null, null], "label": "1:-1:0.14286"}`