### PR TITLE
Record context for interactions

### DIFF
--- a/coba/experiments/tasks.py
+++ b/coba/experiments/tasks.py
@@ -69,7 +69,7 @@ class EvaluationTask(ABC):
 class SimpleEvaluation(EvaluationTask):
 
     def __init__(self, 
-        record: Sequence[Literal['reward','rank','regret','time','probability','action']] = ['reward'], 
+        record: Sequence[Literal['reward','rank','regret','time','probability','action', 'context']] = ['reward'],
         learn: bool = True,
         predict: bool = True) -> None:
         """
@@ -87,9 +87,10 @@ class SimpleEvaluation(EvaluationTask):
 
         learner = SafeLearner(learner)
 
-        record_prob   = 'probability' in self._record
-        record_time   = 'time'        in self._record
-        record_action = 'action'      in self._record
+        record_prob    = 'probability' in self._record
+        record_time    = 'time'        in self._record
+        record_action  = 'action'      in self._record
+        record_context = 'context'     in self._record
 
         first, interactions = peek_first(interactions)
 
@@ -132,9 +133,9 @@ class SimpleEvaluation(EvaluationTask):
             out     = {}
             context = interaction.pop('context')
             batched = isinstance(context, Batch)
+            if record_context: out['context'] = context
 
             if is_predict:
-
                 actions   = interaction.pop('actions')
                 rewards   = interaction.pop('rewards')
                 feedbacks = interaction.pop('feedbacks',None)
@@ -146,10 +147,10 @@ class SimpleEvaluation(EvaluationTask):
                 reward   = rewards.eval(action)
                 feedback = feedbacks.eval(action) if feedbacks else reward
 
-                if record_time  : out['predict_time'] = predict_time
-                if record_prob  : out['probability']  = prob
-                if record_action: out['action']       = action
-                if feedbacks    : out['feedback']     = feedback
+                if record_time   : out['predict_time'] = predict_time
+                if record_prob   : out['probability']  = prob
+                if record_action : out['action']       = action
+                if feedbacks     : out['feedback']     = feedback
 
                 if not batched:
                     if calc_reward : out['reward'] = get_reward(reward)
@@ -161,7 +162,6 @@ class SimpleEvaluation(EvaluationTask):
                     if calc_rank   : out['rank'  ] = mean(map(get_rank  ,reward,rewards,len(actions)))
 
             if is_learn:
-
                 if is_off_policy_learn:
                     actions  = interaction.pop('actions',actions if is_predict else None)
                     action   = interaction.pop('action')

--- a/coba/experiments/tasks.py
+++ b/coba/experiments/tasks.py
@@ -147,10 +147,10 @@ class SimpleEvaluation(EvaluationTask):
                 reward   = rewards.eval(action)
                 feedback = feedbacks.eval(action) if feedbacks else reward
 
-                if record_time   : out['predict_time'] = predict_time
-                if record_prob   : out['probability']  = prob
-                if record_action : out['action']       = action
-                if feedbacks     : out['feedback']     = feedback
+                if record_time  : out['predict_time'] = predict_time
+                if record_prob  : out['probability']  = prob
+                if record_action: out['action']       = action
+                if feedbacks    : out['feedback']     = feedback
 
                 if not batched:
                     if calc_reward : out['reward'] = get_reward(reward)

--- a/coba/tests/test_experiments_tasks.py
+++ b/coba/tests/test_experiments_tasks.py
@@ -655,6 +655,25 @@ class SimpleEvaluation_Tests(unittest.TestCase):
         self.assertAlmostEqual(0, task_results[0]["predict_time"], places=1)
         self.assertAlmostEqual(0, task_results[0]["learn_time"]  , places=1)
 
+    def test_context_logging(self):
+        task         = SimpleEvaluation(['reward','probability', 'context'])
+        learner      = RecordingLearner()
+        interactions = [
+            LoggedInteraction(1, 0, 0),
+            LoggedInteraction(2, 0, 0),
+            LoggedInteraction(3, 0, 0),
+            LoggedInteraction(4, 0, 0, actions=[2, 5, 8], probability=.2),
+            LoggedInteraction(5, 0, 0, actions=[2, 5, 8], probability=.2),
+            LoggedInteraction(6, 0, 0, actions=[2, 5, 8], probability=.2),
+            SimulatedInteraction(None,[1,2,3],[7,8,9]),
+            SimulatedInteraction(None,[4,5,6],[4,5,6]),
+            SimulatedInteraction(None,[7,8,9],[1,2,3]),
+        ]
+
+        task_results = list(task.process(learner, interactions))
+        result_contexts = [result['context'] for result in task_results]
+        self.assertListEqual(result_contexts, [1, 2, 3, 4, 5, 6, None, None, None])
+
     def test_batched_simulated_interaction(self):
 
         class SimpleLearner:

--- a/coba/tests/test_experiments_tasks.py
+++ b/coba/tests/test_experiments_tasks.py
@@ -656,9 +656,10 @@ class SimpleEvaluation_Tests(unittest.TestCase):
         self.assertAlmostEqual(0, task_results[0]["learn_time"]  , places=1)
 
     def test_context_logging(self):
-        task         = SimpleEvaluation(['reward','probability', 'context'])
-        learner      = RecordingLearner()
-        interactions = [
+        task                 = SimpleEvaluation(['reward','probability', 'context'])
+        task_without_context = SimpleEvaluation(['reward','probability'])
+        learner              = RecordingLearner()
+        interactions         = [
             LoggedInteraction(1, 0, 0),
             LoggedInteraction(2, 0, 0),
             LoggedInteraction(3, 0, 0),
@@ -669,7 +670,11 @@ class SimpleEvaluation_Tests(unittest.TestCase):
             SimulatedInteraction(None,[4,5,6],[4,5,6]),
             SimulatedInteraction(None,[7,8,9],[1,2,3]),
         ]
+        # without recording context
+        task_results = list(task_without_context.process(learner, interactions))
+        self.assertNotIn('context', task_results[0])
 
+        # recording context
         task_results = list(task.process(learner, interactions))
         result_contexts = [result['context'] for result in task_results]
         self.assertListEqual(result_contexts, [1, 2, 3, 4, 5, 6, None, None, None])


### PR DESCRIPTION
This change adds `context` to the metrics which can be `record`ed for interactions in the task evaluation.
This is particularly useful for performing analyses like feature importance on experiment results.