### PR TITLE
remove ope_loss from out update

### DIFF
--- a/coba/experiments/tasks.py
+++ b/coba/experiments/tasks.py
@@ -219,19 +219,21 @@ class SimpleEvaluation(EvaluationTask):
                         out['ope_loss'] = float("nan")
 
             if interaction:
-                interaction.pop("actions",None)
-                interaction.pop("rewards",None)
-                interaction.pop("action",None)
-                interaction.pop("reward",None)
-                interaction.pop("probability",None)
-                out.update(interaction)
+                METRICS_EXCLUDED_FROM_OUT_UPDATE = {
+                    "actions",
+                    "rewards",
+                    "action",
+                    "reward",
+                    "probability",
+                    "ope_loss"
+                }
+                out.update({k: v for k, v in interaction.items() if k not in METRICS_EXCLUDED_FROM_OUT_UPDATE})
 
             if learning_info:
                 out.update(learning_info)
                 learning_info.clear()
 
             if out:
-
                 # for off-policy evaluation purposes we need to log each reward even when batching.
                 # Therefore, we have two options:
                 #   (1) store a batched version of reward and keep out batched. With this option we


### PR DESCRIPTION
I came across this issue in the synthetic data generation online/offline learner notebook when the random learner would have `ope_loss` values in its interaction results (even though it should be NaN).

Stepping through the code it showed the `interaction` dict had `ope_loss` set as a field and before the introduced change the `ope_loss` value would be overridden in `out`. 

<img width="1728" alt="Screenshot 2023-03-13 at 8 41 31 AM" src="https://user-images.githubusercontent.com/1749498/224824917-b7c838b5-430e-49fe-a338-1caf1a2898da.png">

This code change fixes the issue but I think `ope_loss` shouldn't be set in the `interaction` dict in the first place and I am not quite sure where it comes from. 
The whole logic of popping items out of the `interaction` and then using them in the end to update the `out`put also seems a bit brittle. 

Raising this as a draft first to discuss the best path forward, @mrucker 