### PR TITLE
add context to default interaction terms

### DIFF
--- a/coba/learners/vowpal.py
+++ b/coba/learners/vowpal.py
@@ -15,7 +15,7 @@ Namespaces    = Dict[str,Features]
 VW_Features   = Sequence[Union[str,int,Tuple[Union[str,int],Union[int,float]],Dict[str,Union[int,float]]]]
 VW_Namespaces = Dict[str,VW_Features]
 
-DEFAULT_NAMESPACE_INTERACTIONS = (1, 'a', 'ax', 'axx')
+DEFAULT_NAMESPACE_INTERACTIONS = (1, 'x', 'a', 'ax', 'axx')
 
 class VowpalMediator:
     """A class to handle all communication between Coba and VW."""


### PR DESCRIPTION
It's fairly risky to change the default behavior of learners but I've been pulling my hair why some of my models weren't learning anything with the synthetic data generation just to realize it's because I've used the default interaction terms instead of my manually provided list.

Is there a reason for omitting the context term?

<img width="746" alt="Screenshot 2023-04-17 at 9 49 42 PM" src="https://user-images.githubusercontent.com/1749498/232596245-97052860-360c-4fda-8720-eb45788f0eef.png">
