### PR TITLE
JSON encoding support for rewards + some misc

### DIFF
--- a/coba/encodings.py
+++ b/coba/encodings.py
@@ -310,7 +310,10 @@ class CobaJsonEncoder(json.JSONEncoder):
         try:
             return o.to_json()
         except AttributeError:
-            return vars(o)
+            try:
+                return vars(o)
+            except TypeError:
+                return super().default(o)
 
 class CobaJsonDecoder(json.JSONDecoder):
     """A json decoder that allows for potential COBA extensions in the future."""

--- a/coba/encodings.py
+++ b/coba/encodings.py
@@ -306,6 +306,11 @@ class FactorEncoder(Encoder[int]):
 
 class CobaJsonEncoder(json.JSONEncoder):
     """A json encoder that allows for potential COBA extensions in the future."""
+    def default(self, o: Any) -> Any:
+        try:
+            return o.to_json()
+        except AttributeError:
+            return vars(o)
 
 class CobaJsonDecoder(json.JSONDecoder):
     """A json decoder that allows for potential COBA extensions in the future."""

--- a/coba/evaluators/online.py
+++ b/coba/evaluators/online.py
@@ -290,7 +290,7 @@ class OffPolicyEvaluator(Evaluator):
 class ExplorationEvaluator(Evaluator):
 
     def __init__(self,
-        record: Sequence[Literal['context','actions','action','reward','probability','time']] = ['reward'],
+        record: Sequence[Literal['context','actions','action','reward','probability','time','rewards']] = ['reward'],
         ope: bool = None,
         qpct: float = .005,
         cmax: float = 1.0,
@@ -367,6 +367,7 @@ class ExplorationEvaluator(Evaluator):
         record_context  = 'context'     in self._record
         record_prob     = 'probability' in self._record
         record_ope_loss = 'ope_loss'    in self._record
+        record_rewards  = 'rewards'     in self._record
 
         request = learner.request
         learn   = learner.learn
@@ -394,10 +395,6 @@ class ExplorationEvaluator(Evaluator):
             log_prob         = interaction.pop('probability')
             log_rewards      = interaction.pop('rewards',None)
             log_action_index = log_actions.index(log_action)
-
-            if record_time:
-                predict_time = 0
-                learn_time   = 0
 
             start_time = time.time()
             on_probs = request(log_context,log_actions,log_actions)
@@ -440,6 +437,8 @@ class ExplorationEvaluator(Evaluator):
                 if record_reward  : out['reward']       = mean(ope_rewards)
                 if record_prob    : out['probability']  = on_prob
                 if record_ope_loss: out['ope_loss']     = get_ope_loss(learner)
+                if record_rewards : out['rewards']      = ope_rewards
+
 
                 if info: out.update(info)
                 if out : yield out

--- a/coba/evaluators/online.py
+++ b/coba/evaluators/online.py
@@ -148,7 +148,7 @@ class OffPolicyEvaluator(Evaluator):
         """
         Args:
             record: The datapoints to record for each interaction.
-            learn: Indicates that off-policy learning should occur as parrt of the off-policy task.
+            learn: Indicates that off-policy learning should occur as part of the off-policy task.
             evals: Indicates that off-policy evaluation should occur as part of the off-policy task.
             seed: Provide an explicit seed to use during evaluation. If not provided a default is used.
         """

--- a/coba/primitives/rewards.py
+++ b/coba/primitives/rewards.py
@@ -22,10 +22,13 @@ class Reward(ABC):
     def eval(self, action: Action) -> float:
         ...
 
+    def to_json(self) -> Mapping[str, str]:
+        return {key.lstrip('_'): getattr(self, key, None) for key in self.__slots__}
+
 class IPSReward(Reward):
     __slots__ = ('_reward','_action')
 
-    def __init__(self, reward: float, action: Action, probability: Optional[float]) -> None:
+    def __init__(self, reward: float, action: Action, probability: Optional[float] = None) -> None:
         self._reward = reward/(probability or 1)
         self._action = action
 

--- a/coba/tests/test_pipes_filters.py
+++ b/coba/tests/test_pipes_filters.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 
-from coba import IPSReward
+from coba import IPSReward, MappingReward
 from coba.pipes import Flatten, Encode, JsonEncode, Structure, LazyDense, LazySparse
 from coba.pipes import Take, Identity, Shuffle, Default, Reservoir, Cache
 from coba.encodings import NumericEncoder, OneHotEncoder, StringEncoder
@@ -358,10 +358,20 @@ class JsonEncode_Tests(unittest.TestCase):
     def test_not_minified_list(self):
         self.assertEqual('[1.0, 2.0]',JsonEncode(minify=False).filter([1.,2.]))
 
-    def test_reward_encode(self):
+    def test_ips_reward_encode(self):
         reward = IPSReward(1000, "action_1", 0.5)
         self.assertEqual('{"reward":2000.0,"action":"action_1"}',JsonEncode().filter(reward))
         self.assertEqual(IPSReward(**json.loads(JsonEncode().filter(reward))), reward)
+
+    def test_mapping_reward_encode(self):
+        reward = MappingReward({
+            "action_1": 1000,
+            "action_2": 2000,
+            "action_3": 3000
+        })
+        self.assertEqual('{"mapping":{"action_1":1000,"action_2":2000,"action_3":3000}}', JsonEncode().filter(reward))
+        self.assertEqual(MappingReward(**json.loads(JsonEncode().filter(reward))), reward)
+
 
 class Structure_Tests(unittest.TestCase):
 

--- a/coba/tests/test_pipes_filters.py
+++ b/coba/tests/test_pipes_filters.py
@@ -1,6 +1,7 @@
+import json
 import unittest
 
-
+from coba import IPSReward
 from coba.pipes import Flatten, Encode, JsonEncode, Structure, LazyDense, LazySparse
 from coba.pipes import Take, Identity, Shuffle, Default, Reservoir, Cache
 from coba.encodings import NumericEncoder, OneHotEncoder, StringEncoder
@@ -356,6 +357,11 @@ class JsonEncode_Tests(unittest.TestCase):
 
     def test_not_minified_list(self):
         self.assertEqual('[1.0, 2.0]',JsonEncode(minify=False).filter([1.,2.]))
+
+    def test_reward_encode(self):
+        reward = IPSReward(1000, "action_1", 0.5)
+        self.assertEqual('{"reward":2000.0,"action":"action_1"}',JsonEncode().filter(reward))
+        self.assertEqual(IPSReward(**json.loads(JsonEncode().filter(reward))), reward)
 
 class Structure_Tests(unittest.TestCase):
 


### PR DESCRIPTION
Added JSON serialization support for Reward subclasses for this issue:

```
2023-07-18 14:18:16 -- pid-4977   -- Unexpected exception:

  File "/mnt/user-home/git/coba/coba/experiments/core.py", line 168, in run
    Pipes.join(workitems, chunker, process, preamble, encode, sink).run()
  File "/mnt/user-home/git/coba/coba/pipes/primitives.py", line 181, in run
    sink.write(item)
  File "/mnt/user-home/git/coba/coba/pipes/sinks.py", line 71, in write
    batch = self._get_batch(lines)
  File "/mnt/user-home/git/coba/coba/pipes/sinks.py", line 79, in _get_batch
    if self._batch: batch = list(batch)
  File "/mnt/user-home/git/coba/coba/experiments/results.py", line 454, in filter
    yield encoder.filter(["I", item[1], { "_packed": rows_T }])
  File "/mnt/user-home/git/coba/coba/pipes/filters.py", line 228, in filter
    return self._encoder.encode(self._min(copy.deepcopy([item]))[0] if self._minify else item).replace('"|',"").replace('|"',"")
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

  TypeError: Object of type IPSReward is not JSON serializable
```
and

```
2023-07-18 15:28:01 -- pid-5483   -- Unexpected exception:

  File "/mnt/user-home/git/coba/coba/experiments/core.py", line 168, in run
    Pipes.join(workitems, chunker, process, preamble, encode, sink).run()
  File "/mnt/user-home/git/coba/coba/pipes/primitives.py", line 181, in run
    sink.write(item)
  File "/mnt/user-home/git/coba/coba/pipes/sinks.py", line 71, in write
    batch = self._get_batch(lines)
  File "/mnt/user-home/git/coba/coba/pipes/sinks.py", line 79, in _get_batch
    if self._batch: batch = list(batch)
  File "/mnt/user-home/git/coba/coba/experiments/results.py", line 454, in filter
    yield encoder.filter(["I", item[1], { "_packed": rows_T }])
  File "/mnt/user-home/git/coba/coba/pipes/filters.py", line 228, in filter
    return self._encoder.encode(self._min(copy.deepcopy([item]))[0] if self._minify else item).replace('"|',"").replace('|"',"")
  File "/usr/lib/python3.8/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.8/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.8/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '

  TypeError: Object of type MappingReward is not JSON serializable
```